### PR TITLE
Allow search engine crawlers to read noindex meta tags

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,21 @@
-# Block all web crawlers from all content
+# Allow major search engine crawlers to access pages so they can see noindex meta tags and de-index
+# Without crawl access, search engines cannot read the noindex directive and may keep URLs indexed
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: Slurp
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+# Block all other web crawlers from all content
 User-agent: *
 Disallow: /
 
@@ -39,20 +56,6 @@ Disallow: /
 User-agent: YandexBot
 Disallow: /
 
-User-agent: DuckDuckBot
-Disallow: /
-
-User-agent: Applebot
-Disallow: /
-
-User-agent: Slurp
-Disallow: /
-
-User-agent: Bingbot
-Disallow: /
-
-User-agent: Googlebot
-Disallow: /
 
 # Block archive crawlers
 User-agent: ia_archiver


### PR DESCRIPTION
## Summary
- Allow Googlebot, Bingbot, Slurp, DuckDuckBot, and Applebot to crawl in `robots.txt` so they can read the `noindex` meta tags already present in the app
- Pages were still showing as indexed because `robots.txt` was blocking crawlers from seeing the `noindex` directives — search engines kept URLs in the index since they couldn't verify the noindex instruction
- All AI crawlers (GPTBot, CCBot, anthropic-ai, etc.) and SEO crawlers remain blocked

## Test plan
- [ ] Deploy and verify `robots.txt` is served correctly at `/robots.txt`
- [ ] Use Google Search Console to request re-indexing and confirm pages start getting de-indexed
- [ ] Verify noindex meta tags are still present in page source (`<meta name="robots" content="noindex, ...">`)
- [ ] Confirm `X-Robots-Tag` header is still returned on all responses

https://claude.ai/code/session_015iMXCPDHFemVBh6RSijjkn